### PR TITLE
Unlisted publicity

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE Users (
     password_hash TEXT NOT NULL
 );
 
-CREATE TYPE Publicity AS ENUM ('listed', 'private');
+CREATE TYPE Publicity AS ENUM ('listed', 'unlisted', 'private');
 
 CREATE TABLE Pastes (
     id SERIAL PRIMARY KEY,

--- a/templates/paste.html
+++ b/templates/paste.html
@@ -26,6 +26,7 @@
                 <select name="publicity" {{ fieldsDisabled }}>
                     <option disabled>-- Publicity --</option>
                     <option value="listed" {{ 'selected' if pastePublicity == 'listed' else '' }}>Listed on the front page</option>
+                    <option value="unlisted" {{ 'selected' if pastePublicity == 'unlisted' else '' }}>Anyone with link</option>
                     <option value="private" {{ 'selected' if pastePublicity == 'private' else '' }}>Only for you</option>
                 </select>
             </p>


### PR DESCRIPTION
This simple change adds the third publicity value: unlisted. Unlisted pastes can be accessed by anyone with token, but they won't be listed on the front page.